### PR TITLE
Move models to /opt/models

### DIFF
--- a/kaldi/README.md
+++ b/kaldi/README.md
@@ -121,7 +121,7 @@ This will run a container providing an [HTTP API](#http-api) binded on the host 
 | HOST_SERVING_PORT | Host serving port | 80 |
 | AM_PATH | Path to the acoustic model on the host machine mounted to /opt/AM | /my/path/to/models/AM_fr-FR_v2.2.0 |
 | LM_PATH | Path to the language model on the host machine mounted to /opt/LM | /my/path/to/models/fr-FR_big-v2.2.0 |
-| MODEL_PATH | Path to the model (using MODEL_TYPE=vosk) mounted to /opt/model | /my/path/to/models/vosk-model |
+| MODEL_PATH | Path to the model (using MODEL_TYPE=vosk) mounted to /opt/models | /my/path/to/models/vosk-model |
 
 ### Celery task
 The TASK serving mode connect a celery worker to a message broker.
@@ -144,7 +144,7 @@ linto-stt-kaldi:latest
 |:-|:-|:-|
 | AM_PATH | Path to the acoustic model on the host machine mounted to /opt/AM | /my/path/to/models/AM_fr-FR_v2.2.0 |
 | LM_PATH | Path to the language model on the host machine mounted to /opt/LM | /my/path/to/models/fr-FR_big-v2.2.0 |
-| MODEL_PATH | Path to the model (using MODEL_TYPE=vosk) mounted to /opt/model | /my/path/to/models/vosk-model |
+| MODEL_PATH | Path to the model (using MODEL_TYPE=vosk) mounted to /opt/models | /my/path/to/models/vosk-model |
 | SHARED_AUDIO_FOLDER | Shared audio folder mounted to /opt/audio | /my/path/to/models/vosk-model |
 
 

--- a/kaldi/stt/processing/__init__.py
+++ b/kaldi/stt/processing/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 # Model locations (should be mounted)
-MODEL_PATH = "/opt/model"
+MODEL_PATH = "/opt/models"
 
 # Load ASR models (acoustic model and decoding graph)
 logger.info("Loading acoustic model and decoding graph ...")

--- a/whisper/README.md
+++ b/whisper/README.md
@@ -238,8 +238,8 @@ This will run a container providing an [HTTP API](#http-api) binded on the host 
 You may also want to add specific options:
 * To enable GPU capabilities, add ```--gpus all```.
   Note that you can use environment variable `DEVICE=cuda` to make sure GPU is used (and maybe set `CUDA_VISIBLE_DEVICES` if there are several available GPU cards).
-* To mount a local cache folder `<CACHE_PATH>` (e.g. "`$HOME/.cache`") and avoid downloading models each time,
-  use ```-v <CACHE_PATH>:/root/.cache```
+* To mount a local cache folder `<CACHE_PATH>` (e.g. "`/opt/models`") and avoid downloading models each time,
+  use ```-v <CACHE_PATH>:/opt/models```
   If you use `MODEL=/opt/model.pt` environment variable, you may want to mount the model file (or folder) with option ```-v <ASR_PATH>:/opt/model.pt```.
 * If you want to specifiy a custom alignment model already downloaded in a folder `<WAV2VEC_PATH>`,
   you can add option ```-v <WAV2VEC_PATH>:/opt/wav2vec``` and environment variable ```ALIGNMENT_MODEL=/opt/wav2vec```.
@@ -248,7 +248,7 @@ You may also want to add specific options:
 | Variables | Description | Example |
 |:-|:-|:-|
 | `HOST_SERVING_PORT` | Host serving port | 8080 |
-| `<CACHE_PATH>` | Path to a folder to download wav2vec alignment models when relevant | /home/username/.cache |
+| `<CACHE_PATH>` | Path to a folder to download wav2vec alignment models when relevant | /opt/models |
 | `<ASR_PATH>` | Path to the Whisper model on the host machine mounted to /opt/model.pt | /my/path/to/models/medium.pt |
 | `<WAV2VEC_PATH>` | Path to a folder to a custom wav2vec alignment model |  /my/path/to/models/wav2vec |
 
@@ -269,8 +269,8 @@ linto-stt-whisper:latest
 You may also want to add specific options:
 * To enable GPU capabilities, add ```--gpus all```.
   Note that you can use environment variable `DEVICE=cuda` to make sure GPU is used (and maybe set `CUDA_VISIBLE_DEVICES` if there are several available GPU cards).
-* To mount a local cache folder `<CACHE_PATH>` (e.g. "`$HOME/.cache`") and avoid downloading models each time,
-  use ```-v <CACHE_PATH>:/root/.cache```
+* To mount a local cache folder `<CACHE_PATH>` (e.g. "`/opt/models`") and avoid downloading models each time,
+  use ```-v <CACHE_PATH>:/opt/models```
   If you use `MODEL=/opt/model.pt` environment variable, you may want to mount the model file (or folder) with option ```-v <ASR_PATH>:/opt/model.pt```.
 * If you want to specifiy a custom alignment model already downloaded in a folder `<WAV2VEC_PATH>`,
   you can add option ```-v <WAV2VEC_PATH>:/opt/wav2vec``` and environment variable ```ALIGNMENT_MODEL=/opt/wav2vec```.
@@ -279,7 +279,7 @@ You may also want to add specific options:
 | Variables | Description | Example |
 |:-|:-|:-|
 | `<SHARED_AUDIO_FOLDER>` | Shared audio folder mounted to /opt/audio | /my/path/to/models/vosk-model |
-| `<CACHE_PATH>` | Path to a folder to download wav2vec alignment models when relevant | /home/username/.cache |
+| `<CACHE_PATH>` | Path to a folder to download wav2vec alignment models when relevant | /opt/models |
 | `<ASR_PATH>` | Path to the Whisper model on the host machine mounted to /opt/model.pt | /my/path/to/models/medium.pt |
 | `<WAV2VEC_PATH>` | Path to a folder to a custom wav2vec alignment model |  /my/path/to/models/wav2vec |
 

--- a/whisper/docker-entrypoint.sh
+++ b/whisper/docker-entrypoint.sh
@@ -57,8 +57,7 @@ function setup_user() {
     # Grant full permissions to /opt for user $USER_NAME
     # Needed for downloading the models
     echo "Granting full permissions to $USER_NAME on /opt"
-    chmod g+rwx /opt
-    usermod -aG $(stat -c %G /opt) "$USER_NAME"
+    chown -R "$USER_NAME:$GROUP_NAME" /opt
 }
 
 # Check model

--- a/whisper/stt/processing/load_model.py
+++ b/whisper/stt/processing/load_model.py
@@ -17,11 +17,14 @@ def load_whisper_model(model_type_or_file, device="cpu", download_root=None):
 
     logger.info("Loading Whisper model {}...".format(model_type_or_file))
 
-    default_cache_root = os.path.join(os.path.expanduser("~"), ".cache")
+    default_cache_root = "/opt/models"
     if download_root is None:
         download_root = default_cache_root
 
+    whisper_kwargs = {}
+
     if USE_CTRANSLATE2:
+        whisper_kwargs["cache_dir"] = os.path.join(download_root, ".cache/huggingface")
         if not os.path.isdir(model_type_or_file):
             # Note: There is no good way to set the root cache directory
             #       with the current version of faster_whisper:
@@ -169,6 +172,7 @@ def load_whisper_model(model_type_or_file, device="cpu", download_root=None):
             model_type_or_file,
             device=device,
             download_root=download_root,
+            **whisper_kwargs,
         )
         model.eval()
         model.requires_grad_(False)


### PR DESCRIPTION
Models are stored in USER home. It's better to use a fixed place not depending on the user.

Move models to /opt/models